### PR TITLE
Update MinPushSize to use uint

### DIFF
--- a/bscript/script.go
+++ b/bscript/script.go
@@ -405,8 +405,8 @@ func (s *Script) EqualsHex(h string) bool {
 }
 
 // MinPushSize returns the minimum size of a push operation of the given data.
-func MinPushSize(bb []byte) int {
-	l := len(bb)
+func MinPushSize(bb []byte) uint {
+	l := uint(len(bb))
 
 	// data length is larger than max supported
 	if l > 0xffffffff {

--- a/bscript/script_test.go
+++ b/bscript/script_test.go
@@ -377,7 +377,7 @@ func TestScript_MinPushSize(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
 		data   [][]byte
-		expLen int
+		expLen uint
 	}{
 		"OpX / OpNeg returns 1": {
 			data: [][]byte{


### PR DESCRIPTION
Building for 32bit in TinyGo for a web-assembly build, comparing an `int` to `0xffffffff` leads to the following build error:

`github.com/libsv/go-bt/v2@v2.1.0-beta.4/bscript/script.go:412:9: 0xffffffff (untyped int constant 4294967295) overflows int`

I have updated both the function and the test to use uint, which solves the problem